### PR TITLE
refactor: Rename database tables and update configurations

### DIFF
--- a/src/AppTemplate.Infrastructure/Configurations/AppUserConfiguration.cs
+++ b/src/AppTemplate.Infrastructure/Configurations/AppUserConfiguration.cs
@@ -8,26 +8,20 @@ internal sealed class AppUserConfiguration : IEntityTypeConfiguration<AppUser>
 {
     public void Configure(EntityTypeBuilder<AppUser> builder)
     {
-        builder.ToTable("users");
+        builder.ToTable("AppUsers");
         builder.HasKey(user => user.Id);
 
-        // Column Mapping for IdentityId
         builder.Property(u => u.IdentityId)
                .HasColumnName("identity_id")
                .IsRequired();
 
-        // Unique index on IdentityId
         builder.HasIndex(u => u.IdentityId).IsUnique();
 
-        // Configure the relationship with IdentityUser.
-        // Assumes IdentityUser is defined in your Identity context and here
-        // we only have a navigation from AppUser to IdentityUser.
         builder.HasOne(u => u.IdentityUser)
-               .WithOne() // No inverse navigation on IdentityUser.
+               .WithOne()
                .HasForeignKey<AppUser>(u => u.IdentityId)
                .IsRequired();
 
-        // Owned type for NotificationPreference
         builder.OwnsOne(u => u.NotificationPreference, np =>
         {
             np.Property(p => p.IsInAppNotificationEnabled)
@@ -38,12 +32,9 @@ internal sealed class AppUserConfiguration : IEntityTypeConfiguration<AppUser>
               .HasColumnName("push_notification");
         });
 
-        // Seeding an admin user.
-        // Note: Adjust the CreateWithoutRolesForSeeding method if additional value objects are needed.
         var adminUser = AppUser.CreateWithoutRolesForSeeding();
         adminUser.SetIdentityId("b3398ff2-1b43-4af7-812d-eb4347eecbb8");
 
-        // Basic entity seeding
         builder.HasData(new
         {
             adminUser.Id,
@@ -54,7 +45,6 @@ internal sealed class AppUserConfiguration : IEntityTypeConfiguration<AppUser>
             UpdatedOnUtc = adminUser.UpdatedOnUtc
         });
 
-        // Owned type seeding for NotificationPreference
         builder.OwnsOne(u => u.NotificationPreference).HasData(new
         {
             AppUserId = adminUser.Id,

--- a/src/AppTemplate.Infrastructure/Configurations/PermissionConfiguration.cs
+++ b/src/AppTemplate.Infrastructure/Configurations/PermissionConfiguration.cs
@@ -8,17 +8,13 @@ internal sealed class PermissionConfiguration : IEntityTypeConfiguration<Permiss
 {
     public void Configure(EntityTypeBuilder<Permission> builder)
     {
-        // Table Name
-        builder.ToTable("permissions");
+        builder.ToTable("Permissions");
 
-        // Primary Key
         builder.HasKey(p => p.Id);
 
-        // Column Mappings
         builder.Property(p => p.Feature).HasColumnName("feature").IsRequired();
         builder.Property(p => p.Name).HasColumnName("name").IsRequired();
 
-        // Data Seeds
         builder.HasData(
             Permission.UsersRead,
             Permission.UsersCreate,

--- a/src/AppTemplate.Infrastructure/Configurations/RoleConfiguration.cs
+++ b/src/AppTemplate.Infrastructure/Configurations/RoleConfiguration.cs
@@ -10,10 +10,9 @@ internal sealed class RoleConfiguration : IEntityTypeConfiguration<Role>
 {
     public void Configure(EntityTypeBuilder<Role> builder)
     {
-        builder.ToTable("roles");
+        builder.ToTable("Roles");
         builder.HasKey(r => r.Id);
 
-        // Use a value converter for RoleName
         builder.Property(r => r.Name)
             .HasConversion(
                 roleName => roleName.Value,
@@ -21,7 +20,6 @@ internal sealed class RoleConfiguration : IEntityTypeConfiguration<Role>
             .HasColumnName("name")
             .IsRequired();
 
-        // Use a value converter for RoleDefaultFlag
         builder.Property(r => r.IsDefault)
             .HasConversion(
                 flag => flag.Value,
@@ -29,7 +27,6 @@ internal sealed class RoleConfiguration : IEntityTypeConfiguration<Role>
             .HasColumnName("is_default")
             .IsRequired();
 
-        // Data seeding for roles (example)
         builder.HasData(
             new
             {
@@ -49,28 +46,26 @@ internal sealed class RoleConfiguration : IEntityTypeConfiguration<Role>
             }
         );
 
-        // Configure Many-to-Many Relationship with Permissions
         builder
             .HasMany(r => r.Permissions)
             .WithMany(p => p.Roles)
             .UsingEntity<Dictionary<string, object>>(
-                "role_permission",
-                rp => rp
-                    .HasOne<Permission>()
-                    .WithMany()
-                    .HasForeignKey("PermissionId")
-                    .HasConstraintName("FK_role_permission_permissions_PermissionId"),
-                rp => rp
-                    .HasOne<Role>()
-                    .WithMany()
-                    .HasForeignKey("RoleId")
-                    .HasConstraintName("FK_role_permission_roles_RoleId"),
-                rp =>
-                {
-                    rp.HasKey("RoleId", "PermissionId");
+                "RolePermission",
+                    rp => rp
+                        .HasOne<Permission>()
+                        .WithMany()
+                        .HasForeignKey("PermissionId")
+                        .HasConstraintName("FK_RolePermission_Permissions_PermissionId"),
+                    rp => rp
+                        .HasOne<Role>()
+                        .WithMany()
+                        .HasForeignKey("RoleId")
+                        .HasConstraintName("FK_RolePermission_Roles_RoleId"),
+                    rp =>
+                    {
+                        rp.HasKey("RoleId", "PermissionId");
 
-                    // Add AdminRole <-> All Permissions
-                    rp.HasData(
+                        rp.HasData(
                         new { RoleId = Role.Admin.Id, PermissionId = Permission.UsersRead.Id },
                         new { RoleId = Role.Admin.Id, PermissionId = Permission.UsersCreate.Id },
                         new { RoleId = Role.Admin.Id, PermissionId = Permission.UsersUpdate.Id },
@@ -87,29 +82,28 @@ internal sealed class RoleConfiguration : IEntityTypeConfiguration<Role>
                         new { RoleId = Role.DefaultRole.Id, PermissionId = Permission.NotificationsUpdate.Id },
                         new { RoleId = Role.DefaultRole.Id, PermissionId = Permission.UsersRead.Id }
                     );
-                }
+                    }
             );
 
         builder
             .HasMany(r => r.Users)
             .WithMany(u => u.Roles)
             .UsingEntity<Dictionary<string, object>>(
-                "role_user",
+                "RoleUser",
                 ru => ru
                     .HasOne<AppUser>()
                     .WithMany()
                     .HasForeignKey("UserId")
-                    .HasConstraintName("FK_role_user_users_UserId"),
+                    .HasConstraintName("FK_RoleUser_AppUsers_UserId"),
                 ru => ru
                     .HasOne<Role>()
                     .WithMany()
                     .HasForeignKey("RoleId")
-                    .HasConstraintName("FK_role_user_roles_RoleId"),
+                    .HasConstraintName("FK_RoleUser_Roles_RoleId"),
                 ru =>
                 {
                     ru.HasKey("RoleId", "UserId");
 
-                    // Seed Admin User <-> Admin Role
                     ru.HasData(
                         new
                         {

--- a/src/AppTemplate.Infrastructure/Migrations/20250326215516_initial.Designer.cs
+++ b/src/AppTemplate.Infrastructure/Migrations/20250326215516_initial.Designer.cs
@@ -12,7 +12,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace AppTemplate.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    [Migration("20250324191357_initial")]
+    [Migration("20250326215516_initial")]
     partial class initial
     {
         /// <inheritdoc />
@@ -57,14 +57,14 @@ namespace AppTemplate.Infrastructure.Migrations
                     b.HasIndex("IdentityId")
                         .IsUnique();
 
-                    b.ToTable("users", (string)null);
+                    b.ToTable("AppUsers", (string)null);
 
                     b.HasData(
                         new
                         {
                             Id = new Guid("55c7f429-0916-4d84-8b76-d45185d89aa7"),
                             CreatedBy = "System",
-                            CreatedOnUtc = new DateTime(2025, 3, 24, 19, 13, 56, 53, DateTimeKind.Utc).AddTicks(577),
+                            CreatedOnUtc = new DateTime(2025, 3, 26, 21, 55, 15, 423, DateTimeKind.Utc).AddTicks(3910),
                             IdentityId = "b3398ff2-1b43-4af7-812d-eb4347eecbb8"
                         });
                 });
@@ -103,14 +103,14 @@ namespace AppTemplate.Infrastructure.Migrations
 
                     b.HasKey("Id");
 
-                    b.ToTable("permissions", (string)null);
+                    b.ToTable("Permissions", (string)null);
 
                     b.HasData(
                         new
                         {
                             Id = new Guid("33261a4a-c423-4876-8f15-e40068aea5ca"),
                             CreatedBy = "System",
-                            CreatedOnUtc = new DateTime(2025, 3, 24, 19, 13, 56, 57, DateTimeKind.Utc).AddTicks(468),
+                            CreatedOnUtc = new DateTime(2025, 3, 26, 21, 55, 15, 426, DateTimeKind.Utc).AddTicks(7605),
                             Feature = "users",
                             Name = "users:read"
                         },
@@ -118,7 +118,7 @@ namespace AppTemplate.Infrastructure.Migrations
                         {
                             Id = new Guid("9f79a54c-0b54-4de5-94b9-8582a5f32e78"),
                             CreatedBy = "System",
-                            CreatedOnUtc = new DateTime(2025, 3, 24, 19, 13, 56, 57, DateTimeKind.Utc).AddTicks(2090),
+                            CreatedOnUtc = new DateTime(2025, 3, 26, 21, 55, 15, 426, DateTimeKind.Utc).AddTicks(9069),
                             Feature = "users",
                             Name = "users:create"
                         },
@@ -126,7 +126,7 @@ namespace AppTemplate.Infrastructure.Migrations
                         {
                             Id = new Guid("25bb194c-ea15-4339-9f45-5a895c51b626"),
                             CreatedBy = "System",
-                            CreatedOnUtc = new DateTime(2025, 3, 24, 19, 13, 56, 57, DateTimeKind.Utc).AddTicks(2096),
+                            CreatedOnUtc = new DateTime(2025, 3, 26, 21, 55, 15, 426, DateTimeKind.Utc).AddTicks(9074),
                             Feature = "users",
                             Name = "users:update"
                         },
@@ -134,7 +134,7 @@ namespace AppTemplate.Infrastructure.Migrations
                         {
                             Id = new Guid("559dd4ec-4d2e-479d-a0a9-5229ecc04fb4"),
                             CreatedBy = "System",
-                            CreatedOnUtc = new DateTime(2025, 3, 24, 19, 13, 56, 57, DateTimeKind.Utc).AddTicks(2099),
+                            CreatedOnUtc = new DateTime(2025, 3, 26, 21, 55, 15, 426, DateTimeKind.Utc).AddTicks(9075),
                             Feature = "users",
                             Name = "users:delete"
                         },
@@ -142,7 +142,7 @@ namespace AppTemplate.Infrastructure.Migrations
                         {
                             Id = new Guid("d066e4ee-6af2-4857-bd40-b9b058fa2201"),
                             CreatedBy = "System",
-                            CreatedOnUtc = new DateTime(2025, 3, 24, 19, 13, 56, 57, DateTimeKind.Utc).AddTicks(2103),
+                            CreatedOnUtc = new DateTime(2025, 3, 26, 21, 55, 15, 426, DateTimeKind.Utc).AddTicks(9077),
                             Feature = "roles",
                             Name = "roles:read"
                         },
@@ -150,7 +150,7 @@ namespace AppTemplate.Infrastructure.Migrations
                         {
                             Id = new Guid("940c88ad-24fe-4d86-a982-fa5ea224edba"),
                             CreatedBy = "System",
-                            CreatedOnUtc = new DateTime(2025, 3, 24, 19, 13, 56, 57, DateTimeKind.Utc).AddTicks(2105),
+                            CreatedOnUtc = new DateTime(2025, 3, 26, 21, 55, 15, 426, DateTimeKind.Utc).AddTicks(9078),
                             Feature = "roles",
                             Name = "roles:create"
                         },
@@ -158,7 +158,7 @@ namespace AppTemplate.Infrastructure.Migrations
                         {
                             Id = new Guid("346d3cc6-ac81-42b1-8539-cd53f42b6566"),
                             CreatedBy = "System",
-                            CreatedOnUtc = new DateTime(2025, 3, 24, 19, 13, 56, 57, DateTimeKind.Utc).AddTicks(2107),
+                            CreatedOnUtc = new DateTime(2025, 3, 26, 21, 55, 15, 426, DateTimeKind.Utc).AddTicks(9080),
                             Feature = "roles",
                             Name = "roles:update"
                         },
@@ -166,7 +166,7 @@ namespace AppTemplate.Infrastructure.Migrations
                         {
                             Id = new Guid("386e40e9-da38-4d2f-8d02-ac4cbaddf760"),
                             CreatedBy = "System",
-                            CreatedOnUtc = new DateTime(2025, 3, 24, 19, 13, 56, 57, DateTimeKind.Utc).AddTicks(2109),
+                            CreatedOnUtc = new DateTime(2025, 3, 26, 21, 55, 15, 426, DateTimeKind.Utc).AddTicks(9081),
                             Feature = "roles",
                             Name = "roles:delete"
                         },
@@ -174,7 +174,7 @@ namespace AppTemplate.Infrastructure.Migrations
                         {
                             Id = new Guid("0eeb5f27-10fd-430a-9257-a8457107141a"),
                             CreatedBy = "System",
-                            CreatedOnUtc = new DateTime(2025, 3, 24, 19, 13, 56, 57, DateTimeKind.Utc).AddTicks(2111),
+                            CreatedOnUtc = new DateTime(2025, 3, 26, 21, 55, 15, 426, DateTimeKind.Utc).AddTicks(9083),
                             Feature = "permissions",
                             Name = "permissions:read"
                         },
@@ -182,7 +182,7 @@ namespace AppTemplate.Infrastructure.Migrations
                         {
                             Id = new Guid("3050d953-5dcf-4eb0-a18d-a3ce62a0dd3c"),
                             CreatedBy = "System",
-                            CreatedOnUtc = new DateTime(2025, 3, 24, 19, 13, 56, 57, DateTimeKind.Utc).AddTicks(2211),
+                            CreatedOnUtc = new DateTime(2025, 3, 26, 21, 55, 15, 426, DateTimeKind.Utc).AddTicks(9084),
                             Feature = "auditlogs",
                             Name = "auditlogs:read"
                         },
@@ -190,7 +190,7 @@ namespace AppTemplate.Infrastructure.Migrations
                         {
                             Id = new Guid("a03a127b-9a03-46a0-b709-b6919f2598be"),
                             CreatedBy = "System",
-                            CreatedOnUtc = new DateTime(2025, 3, 24, 19, 13, 56, 57, DateTimeKind.Utc).AddTicks(2214),
+                            CreatedOnUtc = new DateTime(2025, 3, 26, 21, 55, 15, 426, DateTimeKind.Utc).AddTicks(9086),
                             Feature = "notifications",
                             Name = "notifications:read"
                         },
@@ -198,7 +198,7 @@ namespace AppTemplate.Infrastructure.Migrations
                         {
                             Id = new Guid("a5585e9e-ec65-431b-9bb9-9bbc1663ebb8"),
                             CreatedBy = "System",
-                            CreatedOnUtc = new DateTime(2025, 3, 24, 19, 13, 56, 57, DateTimeKind.Utc).AddTicks(2216),
+                            CreatedOnUtc = new DateTime(2025, 3, 26, 21, 55, 15, 426, DateTimeKind.Utc).AddTicks(9087),
                             Feature = "notifications",
                             Name = "notifications:update"
                         });
@@ -237,14 +237,14 @@ namespace AppTemplate.Infrastructure.Migrations
 
                     b.HasKey("Id");
 
-                    b.ToTable("roles", (string)null);
+                    b.ToTable("Roles", (string)null);
 
                     b.HasData(
                         new
                         {
                             Id = new Guid("4b606d86-3537-475a-aa20-26aadd8f5cfd"),
                             CreatedBy = "System",
-                            CreatedOnUtc = new DateTime(2025, 3, 24, 19, 13, 56, 63, DateTimeKind.Utc).AddTicks(3999),
+                            CreatedOnUtc = new DateTime(2025, 3, 26, 21, 55, 15, 432, DateTimeKind.Utc).AddTicks(2657),
                             IsDefault = false,
                             Name = "Admin"
                         },
@@ -252,7 +252,7 @@ namespace AppTemplate.Infrastructure.Migrations
                         {
                             Id = new Guid("5dc6ec47-5b7c-4c2b-86cd-3a671834e56e"),
                             CreatedBy = "System",
-                            CreatedOnUtc = new DateTime(2025, 3, 24, 19, 13, 56, 63, DateTimeKind.Utc).AddTicks(4654),
+                            CreatedOnUtc = new DateTime(2025, 3, 26, 21, 55, 15, 432, DateTimeKind.Utc).AddTicks(3113),
                             IsDefault = true,
                             Name = "Registered"
                         });
@@ -377,15 +377,15 @@ namespace AppTemplate.Infrastructure.Migrations
                         {
                             Id = "b3398ff2-1b43-4af7-812d-eb4347eecbb8",
                             AccessFailedCount = 0,
-                            ConcurrencyStamp = "6267cae9-20fe-48dd-982f-1a757f8d0252",
+                            ConcurrencyStamp = "b6b1015e-397e-4251-8559-aef7fc8a6a58",
                             Email = "admin@example.com",
                             EmailConfirmed = true,
                             LockoutEnabled = false,
                             NormalizedEmail = "ADMIN@EXAMPLE.COM",
                             NormalizedUserName = "ADMIN",
-                            PasswordHash = "AQAAAAIAAYagAAAAEMByb9Ia6Gx9Y6uJE6NaFKWolte0JiZ3ScPUme1bkTY94cEd7407w0QiM16vTcfoNg==",
+                            PasswordHash = "AQAAAAIAAYagAAAAEHIU5u89fB0DtgDjmowFzlj1AyWVMP1Q6bz+zueZKex/vzQIIRFTQzSOsLy2veEhjA==",
                             PhoneNumberConfirmed = false,
-                            SecurityStamp = "7847bacf-e833-42ac-98e2-10a82044a338",
+                            SecurityStamp = "5e24ddd3-fd6e-4cee-831d-82573724aa1f",
                             TwoFactorEnabled = false,
                             UserName = "admin"
                         });
@@ -504,7 +504,7 @@ namespace AppTemplate.Infrastructure.Migrations
                     b.ToTable("outbox_messages", (string)null);
                 });
 
-            modelBuilder.Entity("role_permission", b =>
+            modelBuilder.Entity("RolePermission", b =>
                 {
                     b.Property<Guid>("RoleId")
                         .HasColumnType("uuid");
@@ -516,7 +516,7 @@ namespace AppTemplate.Infrastructure.Migrations
 
                     b.HasIndex("PermissionId");
 
-                    b.ToTable("role_permission");
+                    b.ToTable("RolePermission");
 
                     b.HasData(
                         new
@@ -596,7 +596,7 @@ namespace AppTemplate.Infrastructure.Migrations
                         });
                 });
 
-            modelBuilder.Entity("role_user", b =>
+            modelBuilder.Entity("RoleUser", b =>
                 {
                     b.Property<Guid>("RoleId")
                         .HasColumnType("uuid");
@@ -608,7 +608,7 @@ namespace AppTemplate.Infrastructure.Migrations
 
                     b.HasIndex("UserId");
 
-                    b.ToTable("role_user");
+                    b.ToTable("RoleUser");
 
                     b.HasData(
                         new
@@ -650,7 +650,7 @@ namespace AppTemplate.Infrastructure.Migrations
 
                             b1.HasKey("AppUserId");
 
-                            b1.ToTable("users");
+                            b1.ToTable("AppUsers");
 
                             b1.WithOwner()
                                 .HasForeignKey("AppUserId");
@@ -722,38 +722,38 @@ namespace AppTemplate.Infrastructure.Migrations
                         .IsRequired();
                 });
 
-            modelBuilder.Entity("role_permission", b =>
+            modelBuilder.Entity("RolePermission", b =>
                 {
                     b.HasOne("AppTemplate.Domain.Roles.Permission", null)
                         .WithMany()
                         .HasForeignKey("PermissionId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired()
-                        .HasConstraintName("FK_role_permission_permissions_PermissionId");
+                        .HasConstraintName("FK_RolePermission_Permissions_PermissionId");
 
                     b.HasOne("AppTemplate.Domain.Roles.Role", null)
                         .WithMany()
                         .HasForeignKey("RoleId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired()
-                        .HasConstraintName("FK_role_permission_roles_RoleId");
+                        .HasConstraintName("FK_RolePermission_Roles_RoleId");
                 });
 
-            modelBuilder.Entity("role_user", b =>
+            modelBuilder.Entity("RoleUser", b =>
                 {
                     b.HasOne("AppTemplate.Domain.Roles.Role", null)
                         .WithMany()
                         .HasForeignKey("RoleId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired()
-                        .HasConstraintName("FK_role_user_roles_RoleId");
+                        .HasConstraintName("FK_RoleUser_Roles_RoleId");
 
                     b.HasOne("AppTemplate.Domain.AppUsers.AppUser", null)
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired()
-                        .HasConstraintName("FK_role_user_users_UserId");
+                        .HasConstraintName("FK_RoleUser_AppUsers_UserId");
                 });
 #pragma warning restore 612, 618
         }

--- a/src/AppTemplate.Infrastructure/Migrations/20250326215516_initial.cs
+++ b/src/AppTemplate.Infrastructure/Migrations/20250326215516_initial.cs
@@ -70,7 +70,7 @@ namespace AppTemplate.Infrastructure.Migrations
                 });
 
             migrationBuilder.CreateTable(
-                name: "permissions",
+                name: "Permissions",
                 columns: table => new
                 {
                     Id = table.Column<Guid>(type: "uuid", nullable: false),
@@ -84,11 +84,11 @@ namespace AppTemplate.Infrastructure.Migrations
                 },
                 constraints: table =>
                 {
-                    table.PrimaryKey("PK_permissions", x => x.Id);
+                    table.PrimaryKey("PK_Permissions", x => x.Id);
                 });
 
             migrationBuilder.CreateTable(
-                name: "roles",
+                name: "Roles",
                 columns: table => new
                 {
                     Id = table.Column<Guid>(type: "uuid", nullable: false),
@@ -102,7 +102,7 @@ namespace AppTemplate.Infrastructure.Migrations
                 },
                 constraints: table =>
                 {
-                    table.PrimaryKey("PK_roles", x => x.Id);
+                    table.PrimaryKey("PK_Roles", x => x.Id);
                 });
 
             migrationBuilder.CreateTable(
@@ -122,6 +122,32 @@ namespace AppTemplate.Infrastructure.Migrations
                         name: "FK_AspNetRoleClaims_AspNetRoles_RoleId",
                         column: x => x.RoleId,
                         principalTable: "AspNetRoles",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AppUsers",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    in_app_notification = table.Column<bool>(type: "boolean", nullable: false),
+                    email_notification = table.Column<bool>(type: "boolean", nullable: false),
+                    push_notification = table.Column<bool>(type: "boolean", nullable: false),
+                    identity_id = table.Column<string>(type: "text", nullable: false),
+                    CreatedBy = table.Column<string>(type: "text", nullable: false),
+                    UpdatedBy = table.Column<string>(type: "text", nullable: true),
+                    CreatedOnUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedOnUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    DeletedOnUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AppUsers", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AppUsers_AspNetUsers_identity_id",
+                        column: x => x.identity_id,
+                        principalTable: "AspNetUsers",
                         principalColumn: "Id",
                         onDelete: ReferentialAction.Cascade);
                 });
@@ -212,33 +238,7 @@ namespace AppTemplate.Infrastructure.Migrations
                 });
 
             migrationBuilder.CreateTable(
-                name: "users",
-                columns: table => new
-                {
-                    Id = table.Column<Guid>(type: "uuid", nullable: false),
-                    in_app_notification = table.Column<bool>(type: "boolean", nullable: false),
-                    email_notification = table.Column<bool>(type: "boolean", nullable: false),
-                    push_notification = table.Column<bool>(type: "boolean", nullable: false),
-                    identity_id = table.Column<string>(type: "text", nullable: false),
-                    CreatedBy = table.Column<string>(type: "text", nullable: false),
-                    UpdatedBy = table.Column<string>(type: "text", nullable: true),
-                    CreatedOnUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
-                    UpdatedOnUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
-                    DeletedOnUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("PK_users", x => x.Id);
-                    table.ForeignKey(
-                        name: "FK_users_AspNetUsers_identity_id",
-                        column: x => x.identity_id,
-                        principalTable: "AspNetUsers",
-                        principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
-                });
-
-            migrationBuilder.CreateTable(
-                name: "role_permission",
+                name: "RolePermission",
                 columns: table => new
                 {
                     RoleId = table.Column<Guid>(type: "uuid", nullable: false),
@@ -246,23 +246,23 @@ namespace AppTemplate.Infrastructure.Migrations
                 },
                 constraints: table =>
                 {
-                    table.PrimaryKey("PK_role_permission", x => new { x.RoleId, x.PermissionId });
+                    table.PrimaryKey("PK_RolePermission", x => new { x.RoleId, x.PermissionId });
                     table.ForeignKey(
-                        name: "FK_role_permission_permissions_PermissionId",
+                        name: "FK_RolePermission_Permissions_PermissionId",
                         column: x => x.PermissionId,
-                        principalTable: "permissions",
+                        principalTable: "Permissions",
                         principalColumn: "Id",
                         onDelete: ReferentialAction.Cascade);
                     table.ForeignKey(
-                        name: "FK_role_permission_roles_RoleId",
+                        name: "FK_RolePermission_Roles_RoleId",
                         column: x => x.RoleId,
-                        principalTable: "roles",
+                        principalTable: "Roles",
                         principalColumn: "Id",
                         onDelete: ReferentialAction.Cascade);
                 });
 
             migrationBuilder.CreateTable(
-                name: "role_user",
+                name: "RoleUser",
                 columns: table => new
                 {
                     RoleId = table.Column<Guid>(type: "uuid", nullable: false),
@@ -270,17 +270,17 @@ namespace AppTemplate.Infrastructure.Migrations
                 },
                 constraints: table =>
                 {
-                    table.PrimaryKey("PK_role_user", x => new { x.RoleId, x.UserId });
+                    table.PrimaryKey("PK_RoleUser", x => new { x.RoleId, x.UserId });
                     table.ForeignKey(
-                        name: "FK_role_user_roles_RoleId",
-                        column: x => x.RoleId,
-                        principalTable: "roles",
+                        name: "FK_RoleUser_AppUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AppUsers",
                         principalColumn: "Id",
                         onDelete: ReferentialAction.Cascade);
                     table.ForeignKey(
-                        name: "FK_role_user_users_UserId",
-                        column: x => x.UserId,
-                        principalTable: "users",
+                        name: "FK_RoleUser_Roles_RoleId",
+                        column: x => x.RoleId,
+                        principalTable: "Roles",
                         principalColumn: "Id",
                         onDelete: ReferentialAction.Cascade);
                 });
@@ -288,38 +288,43 @@ namespace AppTemplate.Infrastructure.Migrations
             migrationBuilder.InsertData(
                 table: "AspNetUsers",
                 columns: new[] { "Id", "AccessFailedCount", "ConcurrencyStamp", "Email", "EmailConfirmed", "LockoutEnabled", "LockoutEnd", "NormalizedEmail", "NormalizedUserName", "PasswordHash", "PhoneNumber", "PhoneNumberConfirmed", "SecurityStamp", "TwoFactorEnabled", "UserName" },
-                values: new object[] { "b3398ff2-1b43-4af7-812d-eb4347eecbb8", 0, "6267cae9-20fe-48dd-982f-1a757f8d0252", "admin@example.com", true, false, null, "ADMIN@EXAMPLE.COM", "ADMIN", "AQAAAAIAAYagAAAAEMByb9Ia6Gx9Y6uJE6NaFKWolte0JiZ3ScPUme1bkTY94cEd7407w0QiM16vTcfoNg==", null, false, "7847bacf-e833-42ac-98e2-10a82044a338", false, "admin" });
+                values: new object[] { "b3398ff2-1b43-4af7-812d-eb4347eecbb8", 0, "b6b1015e-397e-4251-8559-aef7fc8a6a58", "admin@example.com", true, false, null, "ADMIN@EXAMPLE.COM", "ADMIN", "AQAAAAIAAYagAAAAEHIU5u89fB0DtgDjmowFzlj1AyWVMP1Q6bz+zueZKex/vzQIIRFTQzSOsLy2veEhjA==", null, false, "5e24ddd3-fd6e-4cee-831d-82573724aa1f", false, "admin" });
 
             migrationBuilder.InsertData(
-                table: "permissions",
+                table: "Permissions",
                 columns: new[] { "Id", "CreatedBy", "CreatedOnUtc", "DeletedOnUtc", "feature", "name", "UpdatedBy", "UpdatedOnUtc" },
                 values: new object[,]
                 {
-                    { new Guid("0eeb5f27-10fd-430a-9257-a8457107141a"), "System", new DateTime(2025, 3, 24, 19, 13, 56, 57, DateTimeKind.Utc).AddTicks(2111), null, "permissions", "permissions:read", null, null },
-                    { new Guid("25bb194c-ea15-4339-9f45-5a895c51b626"), "System", new DateTime(2025, 3, 24, 19, 13, 56, 57, DateTimeKind.Utc).AddTicks(2096), null, "users", "users:update", null, null },
-                    { new Guid("3050d953-5dcf-4eb0-a18d-a3ce62a0dd3c"), "System", new DateTime(2025, 3, 24, 19, 13, 56, 57, DateTimeKind.Utc).AddTicks(2211), null, "auditlogs", "auditlogs:read", null, null },
-                    { new Guid("33261a4a-c423-4876-8f15-e40068aea5ca"), "System", new DateTime(2025, 3, 24, 19, 13, 56, 57, DateTimeKind.Utc).AddTicks(468), null, "users", "users:read", null, null },
-                    { new Guid("346d3cc6-ac81-42b1-8539-cd53f42b6566"), "System", new DateTime(2025, 3, 24, 19, 13, 56, 57, DateTimeKind.Utc).AddTicks(2107), null, "roles", "roles:update", null, null },
-                    { new Guid("386e40e9-da38-4d2f-8d02-ac4cbaddf760"), "System", new DateTime(2025, 3, 24, 19, 13, 56, 57, DateTimeKind.Utc).AddTicks(2109), null, "roles", "roles:delete", null, null },
-                    { new Guid("559dd4ec-4d2e-479d-a0a9-5229ecc04fb4"), "System", new DateTime(2025, 3, 24, 19, 13, 56, 57, DateTimeKind.Utc).AddTicks(2099), null, "users", "users:delete", null, null },
-                    { new Guid("940c88ad-24fe-4d86-a982-fa5ea224edba"), "System", new DateTime(2025, 3, 24, 19, 13, 56, 57, DateTimeKind.Utc).AddTicks(2105), null, "roles", "roles:create", null, null },
-                    { new Guid("9f79a54c-0b54-4de5-94b9-8582a5f32e78"), "System", new DateTime(2025, 3, 24, 19, 13, 56, 57, DateTimeKind.Utc).AddTicks(2090), null, "users", "users:create", null, null },
-                    { new Guid("a03a127b-9a03-46a0-b709-b6919f2598be"), "System", new DateTime(2025, 3, 24, 19, 13, 56, 57, DateTimeKind.Utc).AddTicks(2214), null, "notifications", "notifications:read", null, null },
-                    { new Guid("a5585e9e-ec65-431b-9bb9-9bbc1663ebb8"), "System", new DateTime(2025, 3, 24, 19, 13, 56, 57, DateTimeKind.Utc).AddTicks(2216), null, "notifications", "notifications:update", null, null },
-                    { new Guid("d066e4ee-6af2-4857-bd40-b9b058fa2201"), "System", new DateTime(2025, 3, 24, 19, 13, 56, 57, DateTimeKind.Utc).AddTicks(2103), null, "roles", "roles:read", null, null }
+                    { new Guid("0eeb5f27-10fd-430a-9257-a8457107141a"), "System", new DateTime(2025, 3, 26, 21, 55, 15, 426, DateTimeKind.Utc).AddTicks(9083), null, "permissions", "permissions:read", null, null },
+                    { new Guid("25bb194c-ea15-4339-9f45-5a895c51b626"), "System", new DateTime(2025, 3, 26, 21, 55, 15, 426, DateTimeKind.Utc).AddTicks(9074), null, "users", "users:update", null, null },
+                    { new Guid("3050d953-5dcf-4eb0-a18d-a3ce62a0dd3c"), "System", new DateTime(2025, 3, 26, 21, 55, 15, 426, DateTimeKind.Utc).AddTicks(9084), null, "auditlogs", "auditlogs:read", null, null },
+                    { new Guid("33261a4a-c423-4876-8f15-e40068aea5ca"), "System", new DateTime(2025, 3, 26, 21, 55, 15, 426, DateTimeKind.Utc).AddTicks(7605), null, "users", "users:read", null, null },
+                    { new Guid("346d3cc6-ac81-42b1-8539-cd53f42b6566"), "System", new DateTime(2025, 3, 26, 21, 55, 15, 426, DateTimeKind.Utc).AddTicks(9080), null, "roles", "roles:update", null, null },
+                    { new Guid("386e40e9-da38-4d2f-8d02-ac4cbaddf760"), "System", new DateTime(2025, 3, 26, 21, 55, 15, 426, DateTimeKind.Utc).AddTicks(9081), null, "roles", "roles:delete", null, null },
+                    { new Guid("559dd4ec-4d2e-479d-a0a9-5229ecc04fb4"), "System", new DateTime(2025, 3, 26, 21, 55, 15, 426, DateTimeKind.Utc).AddTicks(9075), null, "users", "users:delete", null, null },
+                    { new Guid("940c88ad-24fe-4d86-a982-fa5ea224edba"), "System", new DateTime(2025, 3, 26, 21, 55, 15, 426, DateTimeKind.Utc).AddTicks(9078), null, "roles", "roles:create", null, null },
+                    { new Guid("9f79a54c-0b54-4de5-94b9-8582a5f32e78"), "System", new DateTime(2025, 3, 26, 21, 55, 15, 426, DateTimeKind.Utc).AddTicks(9069), null, "users", "users:create", null, null },
+                    { new Guid("a03a127b-9a03-46a0-b709-b6919f2598be"), "System", new DateTime(2025, 3, 26, 21, 55, 15, 426, DateTimeKind.Utc).AddTicks(9086), null, "notifications", "notifications:read", null, null },
+                    { new Guid("a5585e9e-ec65-431b-9bb9-9bbc1663ebb8"), "System", new DateTime(2025, 3, 26, 21, 55, 15, 426, DateTimeKind.Utc).AddTicks(9087), null, "notifications", "notifications:update", null, null },
+                    { new Guid("d066e4ee-6af2-4857-bd40-b9b058fa2201"), "System", new DateTime(2025, 3, 26, 21, 55, 15, 426, DateTimeKind.Utc).AddTicks(9077), null, "roles", "roles:read", null, null }
                 });
 
             migrationBuilder.InsertData(
-                table: "roles",
+                table: "Roles",
                 columns: new[] { "Id", "CreatedBy", "CreatedOnUtc", "DeletedOnUtc", "is_default", "name", "UpdatedBy", "UpdatedOnUtc" },
                 values: new object[,]
                 {
-                    { new Guid("4b606d86-3537-475a-aa20-26aadd8f5cfd"), "System", new DateTime(2025, 3, 24, 19, 13, 56, 63, DateTimeKind.Utc).AddTicks(3999), null, false, "Admin", null, null },
-                    { new Guid("5dc6ec47-5b7c-4c2b-86cd-3a671834e56e"), "System", new DateTime(2025, 3, 24, 19, 13, 56, 63, DateTimeKind.Utc).AddTicks(4654), null, true, "Registered", null, null }
+                    { new Guid("4b606d86-3537-475a-aa20-26aadd8f5cfd"), "System", new DateTime(2025, 3, 26, 21, 55, 15, 432, DateTimeKind.Utc).AddTicks(2657), null, false, "Admin", null, null },
+                    { new Guid("5dc6ec47-5b7c-4c2b-86cd-3a671834e56e"), "System", new DateTime(2025, 3, 26, 21, 55, 15, 432, DateTimeKind.Utc).AddTicks(3113), null, true, "Registered", null, null }
                 });
 
             migrationBuilder.InsertData(
-                table: "role_permission",
+                table: "AppUsers",
+                columns: new[] { "Id", "CreatedBy", "CreatedOnUtc", "DeletedOnUtc", "identity_id", "UpdatedBy", "UpdatedOnUtc", "email_notification", "in_app_notification", "push_notification" },
+                values: new object[] { new Guid("55c7f429-0916-4d84-8b76-d45185d89aa7"), "System", new DateTime(2025, 3, 26, 21, 55, 15, 423, DateTimeKind.Utc).AddTicks(3910), null, "b3398ff2-1b43-4af7-812d-eb4347eecbb8", null, null, true, true, true });
+
+            migrationBuilder.InsertData(
+                table: "RolePermission",
                 columns: new[] { "PermissionId", "RoleId" },
                 values: new object[,]
                 {
@@ -341,18 +346,19 @@ namespace AppTemplate.Infrastructure.Migrations
                 });
 
             migrationBuilder.InsertData(
-                table: "users",
-                columns: new[] { "Id", "CreatedBy", "CreatedOnUtc", "DeletedOnUtc", "identity_id", "UpdatedBy", "UpdatedOnUtc", "email_notification", "in_app_notification", "push_notification" },
-                values: new object[] { new Guid("55c7f429-0916-4d84-8b76-d45185d89aa7"), "System", new DateTime(2025, 3, 24, 19, 13, 56, 53, DateTimeKind.Utc).AddTicks(577), null, "b3398ff2-1b43-4af7-812d-eb4347eecbb8", null, null, true, true, true });
-
-            migrationBuilder.InsertData(
-                table: "role_user",
+                table: "RoleUser",
                 columns: new[] { "RoleId", "UserId" },
                 values: new object[,]
                 {
                     { new Guid("4b606d86-3537-475a-aa20-26aadd8f5cfd"), new Guid("55c7f429-0916-4d84-8b76-d45185d89aa7") },
                     { new Guid("5dc6ec47-5b7c-4c2b-86cd-3a671834e56e"), new Guid("55c7f429-0916-4d84-8b76-d45185d89aa7") }
                 });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AppUsers_identity_id",
+                table: "AppUsers",
+                column: "identity_id",
+                unique: true);
 
             migrationBuilder.CreateIndex(
                 name: "IX_AspNetRoleClaims_RoleId",
@@ -392,20 +398,14 @@ namespace AppTemplate.Infrastructure.Migrations
                 unique: true);
 
             migrationBuilder.CreateIndex(
-                name: "IX_role_permission_PermissionId",
-                table: "role_permission",
+                name: "IX_RolePermission_PermissionId",
+                table: "RolePermission",
                 column: "PermissionId");
 
             migrationBuilder.CreateIndex(
-                name: "IX_role_user_UserId",
-                table: "role_user",
+                name: "IX_RoleUser_UserId",
+                table: "RoleUser",
                 column: "UserId");
-
-            migrationBuilder.CreateIndex(
-                name: "IX_users_identity_id",
-                table: "users",
-                column: "identity_id",
-                unique: true);
         }
 
         /// <inheritdoc />
@@ -430,22 +430,22 @@ namespace AppTemplate.Infrastructure.Migrations
                 name: "outbox_messages");
 
             migrationBuilder.DropTable(
-                name: "role_permission");
+                name: "RolePermission");
 
             migrationBuilder.DropTable(
-                name: "role_user");
+                name: "RoleUser");
 
             migrationBuilder.DropTable(
                 name: "AspNetRoles");
 
             migrationBuilder.DropTable(
-                name: "permissions");
+                name: "Permissions");
 
             migrationBuilder.DropTable(
-                name: "roles");
+                name: "AppUsers");
 
             migrationBuilder.DropTable(
-                name: "users");
+                name: "Roles");
 
             migrationBuilder.DropTable(
                 name: "AspNetUsers");

--- a/src/AppTemplate.Infrastructure/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/src/AppTemplate.Infrastructure/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -54,14 +54,14 @@ namespace AppTemplate.Infrastructure.Migrations
                     b.HasIndex("IdentityId")
                         .IsUnique();
 
-                    b.ToTable("users", (string)null);
+                    b.ToTable("AppUsers", (string)null);
 
                     b.HasData(
                         new
                         {
                             Id = new Guid("55c7f429-0916-4d84-8b76-d45185d89aa7"),
                             CreatedBy = "System",
-                            CreatedOnUtc = new DateTime(2025, 3, 24, 19, 13, 56, 53, DateTimeKind.Utc).AddTicks(577),
+                            CreatedOnUtc = new DateTime(2025, 3, 26, 21, 55, 15, 423, DateTimeKind.Utc).AddTicks(3910),
                             IdentityId = "b3398ff2-1b43-4af7-812d-eb4347eecbb8"
                         });
                 });
@@ -100,14 +100,14 @@ namespace AppTemplate.Infrastructure.Migrations
 
                     b.HasKey("Id");
 
-                    b.ToTable("permissions", (string)null);
+                    b.ToTable("Permissions", (string)null);
 
                     b.HasData(
                         new
                         {
                             Id = new Guid("33261a4a-c423-4876-8f15-e40068aea5ca"),
                             CreatedBy = "System",
-                            CreatedOnUtc = new DateTime(2025, 3, 24, 19, 13, 56, 57, DateTimeKind.Utc).AddTicks(468),
+                            CreatedOnUtc = new DateTime(2025, 3, 26, 21, 55, 15, 426, DateTimeKind.Utc).AddTicks(7605),
                             Feature = "users",
                             Name = "users:read"
                         },
@@ -115,7 +115,7 @@ namespace AppTemplate.Infrastructure.Migrations
                         {
                             Id = new Guid("9f79a54c-0b54-4de5-94b9-8582a5f32e78"),
                             CreatedBy = "System",
-                            CreatedOnUtc = new DateTime(2025, 3, 24, 19, 13, 56, 57, DateTimeKind.Utc).AddTicks(2090),
+                            CreatedOnUtc = new DateTime(2025, 3, 26, 21, 55, 15, 426, DateTimeKind.Utc).AddTicks(9069),
                             Feature = "users",
                             Name = "users:create"
                         },
@@ -123,7 +123,7 @@ namespace AppTemplate.Infrastructure.Migrations
                         {
                             Id = new Guid("25bb194c-ea15-4339-9f45-5a895c51b626"),
                             CreatedBy = "System",
-                            CreatedOnUtc = new DateTime(2025, 3, 24, 19, 13, 56, 57, DateTimeKind.Utc).AddTicks(2096),
+                            CreatedOnUtc = new DateTime(2025, 3, 26, 21, 55, 15, 426, DateTimeKind.Utc).AddTicks(9074),
                             Feature = "users",
                             Name = "users:update"
                         },
@@ -131,7 +131,7 @@ namespace AppTemplate.Infrastructure.Migrations
                         {
                             Id = new Guid("559dd4ec-4d2e-479d-a0a9-5229ecc04fb4"),
                             CreatedBy = "System",
-                            CreatedOnUtc = new DateTime(2025, 3, 24, 19, 13, 56, 57, DateTimeKind.Utc).AddTicks(2099),
+                            CreatedOnUtc = new DateTime(2025, 3, 26, 21, 55, 15, 426, DateTimeKind.Utc).AddTicks(9075),
                             Feature = "users",
                             Name = "users:delete"
                         },
@@ -139,7 +139,7 @@ namespace AppTemplate.Infrastructure.Migrations
                         {
                             Id = new Guid("d066e4ee-6af2-4857-bd40-b9b058fa2201"),
                             CreatedBy = "System",
-                            CreatedOnUtc = new DateTime(2025, 3, 24, 19, 13, 56, 57, DateTimeKind.Utc).AddTicks(2103),
+                            CreatedOnUtc = new DateTime(2025, 3, 26, 21, 55, 15, 426, DateTimeKind.Utc).AddTicks(9077),
                             Feature = "roles",
                             Name = "roles:read"
                         },
@@ -147,7 +147,7 @@ namespace AppTemplate.Infrastructure.Migrations
                         {
                             Id = new Guid("940c88ad-24fe-4d86-a982-fa5ea224edba"),
                             CreatedBy = "System",
-                            CreatedOnUtc = new DateTime(2025, 3, 24, 19, 13, 56, 57, DateTimeKind.Utc).AddTicks(2105),
+                            CreatedOnUtc = new DateTime(2025, 3, 26, 21, 55, 15, 426, DateTimeKind.Utc).AddTicks(9078),
                             Feature = "roles",
                             Name = "roles:create"
                         },
@@ -155,7 +155,7 @@ namespace AppTemplate.Infrastructure.Migrations
                         {
                             Id = new Guid("346d3cc6-ac81-42b1-8539-cd53f42b6566"),
                             CreatedBy = "System",
-                            CreatedOnUtc = new DateTime(2025, 3, 24, 19, 13, 56, 57, DateTimeKind.Utc).AddTicks(2107),
+                            CreatedOnUtc = new DateTime(2025, 3, 26, 21, 55, 15, 426, DateTimeKind.Utc).AddTicks(9080),
                             Feature = "roles",
                             Name = "roles:update"
                         },
@@ -163,7 +163,7 @@ namespace AppTemplate.Infrastructure.Migrations
                         {
                             Id = new Guid("386e40e9-da38-4d2f-8d02-ac4cbaddf760"),
                             CreatedBy = "System",
-                            CreatedOnUtc = new DateTime(2025, 3, 24, 19, 13, 56, 57, DateTimeKind.Utc).AddTicks(2109),
+                            CreatedOnUtc = new DateTime(2025, 3, 26, 21, 55, 15, 426, DateTimeKind.Utc).AddTicks(9081),
                             Feature = "roles",
                             Name = "roles:delete"
                         },
@@ -171,7 +171,7 @@ namespace AppTemplate.Infrastructure.Migrations
                         {
                             Id = new Guid("0eeb5f27-10fd-430a-9257-a8457107141a"),
                             CreatedBy = "System",
-                            CreatedOnUtc = new DateTime(2025, 3, 24, 19, 13, 56, 57, DateTimeKind.Utc).AddTicks(2111),
+                            CreatedOnUtc = new DateTime(2025, 3, 26, 21, 55, 15, 426, DateTimeKind.Utc).AddTicks(9083),
                             Feature = "permissions",
                             Name = "permissions:read"
                         },
@@ -179,7 +179,7 @@ namespace AppTemplate.Infrastructure.Migrations
                         {
                             Id = new Guid("3050d953-5dcf-4eb0-a18d-a3ce62a0dd3c"),
                             CreatedBy = "System",
-                            CreatedOnUtc = new DateTime(2025, 3, 24, 19, 13, 56, 57, DateTimeKind.Utc).AddTicks(2211),
+                            CreatedOnUtc = new DateTime(2025, 3, 26, 21, 55, 15, 426, DateTimeKind.Utc).AddTicks(9084),
                             Feature = "auditlogs",
                             Name = "auditlogs:read"
                         },
@@ -187,7 +187,7 @@ namespace AppTemplate.Infrastructure.Migrations
                         {
                             Id = new Guid("a03a127b-9a03-46a0-b709-b6919f2598be"),
                             CreatedBy = "System",
-                            CreatedOnUtc = new DateTime(2025, 3, 24, 19, 13, 56, 57, DateTimeKind.Utc).AddTicks(2214),
+                            CreatedOnUtc = new DateTime(2025, 3, 26, 21, 55, 15, 426, DateTimeKind.Utc).AddTicks(9086),
                             Feature = "notifications",
                             Name = "notifications:read"
                         },
@@ -195,7 +195,7 @@ namespace AppTemplate.Infrastructure.Migrations
                         {
                             Id = new Guid("a5585e9e-ec65-431b-9bb9-9bbc1663ebb8"),
                             CreatedBy = "System",
-                            CreatedOnUtc = new DateTime(2025, 3, 24, 19, 13, 56, 57, DateTimeKind.Utc).AddTicks(2216),
+                            CreatedOnUtc = new DateTime(2025, 3, 26, 21, 55, 15, 426, DateTimeKind.Utc).AddTicks(9087),
                             Feature = "notifications",
                             Name = "notifications:update"
                         });
@@ -234,14 +234,14 @@ namespace AppTemplate.Infrastructure.Migrations
 
                     b.HasKey("Id");
 
-                    b.ToTable("roles", (string)null);
+                    b.ToTable("Roles", (string)null);
 
                     b.HasData(
                         new
                         {
                             Id = new Guid("4b606d86-3537-475a-aa20-26aadd8f5cfd"),
                             CreatedBy = "System",
-                            CreatedOnUtc = new DateTime(2025, 3, 24, 19, 13, 56, 63, DateTimeKind.Utc).AddTicks(3999),
+                            CreatedOnUtc = new DateTime(2025, 3, 26, 21, 55, 15, 432, DateTimeKind.Utc).AddTicks(2657),
                             IsDefault = false,
                             Name = "Admin"
                         },
@@ -249,7 +249,7 @@ namespace AppTemplate.Infrastructure.Migrations
                         {
                             Id = new Guid("5dc6ec47-5b7c-4c2b-86cd-3a671834e56e"),
                             CreatedBy = "System",
-                            CreatedOnUtc = new DateTime(2025, 3, 24, 19, 13, 56, 63, DateTimeKind.Utc).AddTicks(4654),
+                            CreatedOnUtc = new DateTime(2025, 3, 26, 21, 55, 15, 432, DateTimeKind.Utc).AddTicks(3113),
                             IsDefault = true,
                             Name = "Registered"
                         });
@@ -374,15 +374,15 @@ namespace AppTemplate.Infrastructure.Migrations
                         {
                             Id = "b3398ff2-1b43-4af7-812d-eb4347eecbb8",
                             AccessFailedCount = 0,
-                            ConcurrencyStamp = "6267cae9-20fe-48dd-982f-1a757f8d0252",
+                            ConcurrencyStamp = "b6b1015e-397e-4251-8559-aef7fc8a6a58",
                             Email = "admin@example.com",
                             EmailConfirmed = true,
                             LockoutEnabled = false,
                             NormalizedEmail = "ADMIN@EXAMPLE.COM",
                             NormalizedUserName = "ADMIN",
-                            PasswordHash = "AQAAAAIAAYagAAAAEMByb9Ia6Gx9Y6uJE6NaFKWolte0JiZ3ScPUme1bkTY94cEd7407w0QiM16vTcfoNg==",
+                            PasswordHash = "AQAAAAIAAYagAAAAEHIU5u89fB0DtgDjmowFzlj1AyWVMP1Q6bz+zueZKex/vzQIIRFTQzSOsLy2veEhjA==",
                             PhoneNumberConfirmed = false,
-                            SecurityStamp = "7847bacf-e833-42ac-98e2-10a82044a338",
+                            SecurityStamp = "5e24ddd3-fd6e-4cee-831d-82573724aa1f",
                             TwoFactorEnabled = false,
                             UserName = "admin"
                         });
@@ -501,7 +501,7 @@ namespace AppTemplate.Infrastructure.Migrations
                     b.ToTable("outbox_messages", (string)null);
                 });
 
-            modelBuilder.Entity("role_permission", b =>
+            modelBuilder.Entity("RolePermission", b =>
                 {
                     b.Property<Guid>("RoleId")
                         .HasColumnType("uuid");
@@ -513,7 +513,7 @@ namespace AppTemplate.Infrastructure.Migrations
 
                     b.HasIndex("PermissionId");
 
-                    b.ToTable("role_permission");
+                    b.ToTable("RolePermission");
 
                     b.HasData(
                         new
@@ -593,7 +593,7 @@ namespace AppTemplate.Infrastructure.Migrations
                         });
                 });
 
-            modelBuilder.Entity("role_user", b =>
+            modelBuilder.Entity("RoleUser", b =>
                 {
                     b.Property<Guid>("RoleId")
                         .HasColumnType("uuid");
@@ -605,7 +605,7 @@ namespace AppTemplate.Infrastructure.Migrations
 
                     b.HasIndex("UserId");
 
-                    b.ToTable("role_user");
+                    b.ToTable("RoleUser");
 
                     b.HasData(
                         new
@@ -647,7 +647,7 @@ namespace AppTemplate.Infrastructure.Migrations
 
                             b1.HasKey("AppUserId");
 
-                            b1.ToTable("users");
+                            b1.ToTable("AppUsers");
 
                             b1.WithOwner()
                                 .HasForeignKey("AppUserId");
@@ -719,38 +719,38 @@ namespace AppTemplate.Infrastructure.Migrations
                         .IsRequired();
                 });
 
-            modelBuilder.Entity("role_permission", b =>
+            modelBuilder.Entity("RolePermission", b =>
                 {
                     b.HasOne("AppTemplate.Domain.Roles.Permission", null)
                         .WithMany()
                         .HasForeignKey("PermissionId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired()
-                        .HasConstraintName("FK_role_permission_permissions_PermissionId");
+                        .HasConstraintName("FK_RolePermission_Permissions_PermissionId");
 
                     b.HasOne("AppTemplate.Domain.Roles.Role", null)
                         .WithMany()
                         .HasForeignKey("RoleId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired()
-                        .HasConstraintName("FK_role_permission_roles_RoleId");
+                        .HasConstraintName("FK_RolePermission_Roles_RoleId");
                 });
 
-            modelBuilder.Entity("role_user", b =>
+            modelBuilder.Entity("RoleUser", b =>
                 {
                     b.HasOne("AppTemplate.Domain.Roles.Role", null)
                         .WithMany()
                         .HasForeignKey("RoleId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired()
-                        .HasConstraintName("FK_role_user_roles_RoleId");
+                        .HasConstraintName("FK_RoleUser_Roles_RoleId");
 
                     b.HasOne("AppTemplate.Domain.AppUsers.AppUser", null)
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired()
-                        .HasConstraintName("FK_role_user_users_UserId");
+                        .HasConstraintName("FK_RoleUser_AppUsers_UserId");
                 });
 #pragma warning restore 612, 618
         }


### PR DESCRIPTION
This commit renames the `users` table to `AppUsers`, the `permissions` table to `Permissions`, and the
`roles` table to `Roles`. The many-to-many relationship tables have also been renamed from `role_permission` to `RolePermission` and from `role_user` to `RoleUser`. Seeding data has been updated to reflect these changes, and foreign key constraints and navigation properties have been adjusted accordingly.