### PR TITLE
feat: VITE_API_URL to use localhost

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,7 @@ services:
     depends_on:
       - apptemplate-web
     environment:
-      VITE_API_URL: "http://apptemplate-web:5070/api/v1"
+      VITE_API_URL: "http://localhost:5070/api/v1"
     ports:
       - "3000:80"
 


### PR DESCRIPTION
Changed the `VITE_API_URL` environment variable in the docker-compose.yml file from the service name `apptemplate-web` to `localhost`, allowing the application to point to the API running on the local machine instead of the Docker service.